### PR TITLE
Add ContextMenu to Tray for linux and win32

### DIFF
--- a/gui/index.js
+++ b/gui/index.js
@@ -135,6 +135,12 @@ app.on('window-all-closed', () => {
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
     tray = new Tray(path.join(__dirname, 'assets/logo-app-icon.png'));
+    tray.setToolTip('ORC')
+    const contextMenu = Menu.buildFromTemplate([
+      {label: 'Open ORC', type: 'normal', click: createWindow},
+      {label: 'Quit ORC', type: 'normal', click: app.quit}
+    ])
+    tray.setContextMenu(contextMenu)
     tray.on('click', createWindow);
   }
 });


### PR DESCRIPTION
As discussed in #87 

Tested on Debian9 Gnome3.22 and Windows10

Does not work on default Ubuntu (16.x, 17.x) yet, see #85 